### PR TITLE
Add runtime classpath normalizations for improved caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -607,6 +607,9 @@
                         <ignore>Build-Date</ignore>
                       </ignoredAttributes>
                     </metaInf>
+                    <ignoredFiles>
+                      <ignore>**/jandex.idx</ignore>
+                    </ignoredFiles>
                   </runtimeClassPath>
                 </normalization>
               </gradleEnterprise>

--- a/pom.xml
+++ b/pom.xml
@@ -595,6 +595,23 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>com.gradle</groupId>
+            <artifactId>gradle-enterprise-maven-extension</artifactId>
+            <configuration>
+              <gradleEnterprise>
+                <normalization>
+                  <runtimeClassPath>
+                    <metaInf>
+                      <ignoredAttributes>
+                        <ignore>Build-Date</ignore>
+                      </ignoredAttributes>
+                    </metaInf>
+                  </runtimeClassPath>
+                </normalization>
+              </gradleEnterprise>
+            </configuration>
+          </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
If we run clean verify twice, making no changes to the build, we can see that quite a few goals re-execute due to differences in their runtime classpaths:

https://ge.solutions-team.gradle.com/c/s2flmthgpxxu6/verujxlxgnevq/goal-inputs?cacheability=cacheable&expanded=WyJnaTR6dmZqdmZ6ajR5LWFubm90YXRpb25wcm9jZXNzb3JwYXRoIl0

If we diff the jars identified by Gradle Enterprise in these two builds, we see that the differences are:
* Build-Date attributes added to the manifest
* Lack of reproducibility in jandex.idx

This PR introduces a set of runtime classpath normalization rules that does not consider these when calculating cache keys for goals that have these jars in the runtime classpath. The result is that goals that rely on these jars can be restored from the cache in scenarios where these are the only input changes.

